### PR TITLE
Use UTF-8 instead of Unicode when saving both .hgignore and .gitignore

### DIFF
--- a/AddDefaultIgnoreFiles.psm1
+++ b/AddDefaultIgnoreFiles.psm1
@@ -1,6 +1,6 @@
 function Add-HgIgnore()
 {
-  (new-object Net.WebClient).DownloadString("https://raw.github.com/skalinets/add-default-ignores/master/Content/hgignore") > .hgignore
+  (new-object Net.WebClient).DownloadString("https://raw.github.com/skalinets/add-default-ignores/master/Content/hgignore") | out-file -encoding UTF8 -filepath .hgignore
 <#
 .Synopsis
     Adds VS optimized .hgignore to current directory.
@@ -15,7 +15,7 @@ function Add-HgIgnore()
 
 function Add-GitIgnore()
 {
-  (new-object Net.WebClient).DownloadString("https://raw.github.com/skalinets/add-default-ignores/master/Content/gitignore") > .gitignore
+  (new-object Net.WebClient).DownloadString("https://raw.github.com/skalinets/add-default-ignores/master/Content/gitignore") | out-file -encoding UTF8 -filepath .gitignore
 
 <#
 .Synopsis


### PR DESCRIPTION
Hi,

When using your module I noticed that it doesn't ignore files and folders which were added to the .gitignore file. And with further investigation found that powershell redirect uses Unicode by default for files (see [this](http://www.johndcook.com/blog/2008/08/25/powershell-output-redirection-unicode-or-ascii/)). I changed the code to use UTF-8 instead. What do you think about it?
